### PR TITLE
Add PocketAnimator mode

### DIFF
--- a/animator.html
+++ b/animator.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <link rel="manifest" href="manifest.json">
+  <script>
+    if (screen.orientation && screen.orientation.lock) {
+      screen.orientation.lock("portrait").catch(() => {});
+    }
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('sw.js');
+    }
+  </script>
+  <title>Pocket Animator</title>
+  <style>
+    body {
+      margin: 0;
+      background: #fefaf6;
+      font-family: sans-serif;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+    }
+    #canvasContainer {
+      position: relative;
+      height: 60vh;
+      overflow: hidden;
+      touch-action: none;
+    }
+    canvas {
+      position: absolute;
+      top: 0;
+      left: 0;
+      touch-action: none;
+    }
+    #frameRail {
+      flex: 1;
+      background: #e8e4df;
+      overflow-x: auto;
+      white-space: nowrap;
+      padding: 4px;
+      box-sizing: border-box;
+      display: flex;
+      gap: 4px;
+    }
+    .thumb {
+      width: 72px;
+      height: 72px;
+      object-fit: cover;
+      border: 2px solid transparent;
+    }
+    .thumb.active {
+      border-color: #000;
+    }
+    #toolbar {
+      position: absolute;
+      bottom: 0; left: 0; right: 0;
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      justify-content: center;
+      padding: 6px;
+      background: rgba(232,228,223,0.9);
+    }
+  </style>
+</head>
+<body>
+  <div id="canvasContainer">
+    <canvas id="layer0"></canvas>
+    <canvas id="layer1"></canvas>
+    <div id="toolbar">
+      <input type="color" id="colorPicker" title="Цвет кисти" value="#000000">
+      <label title="Прозрачность">
+        <input type="range" id="opacityPicker" min="0" max="100" value="100">
+      </label>
+      <label title="Размер кисти">
+        <input type="range" id="sizePicker" min="1" max="50" value="5">
+      </label>
+      <select id="brushShape" title="Тип кисти">
+        <option value="round">Круглая</option>
+        <option value="square">Квадратная</option>
+        <option value="eraser">Ластик</option>
+      </select>
+      <button id="undoBtn" title="Отменить">&#8617;</button>
+      <button id="redoBtn" title="Повторить">&#8618;</button>
+      <button id="clearBtn" title="Очистить">🗑️</button>
+      <button id="addFrameBtn" title="Новый кадр">➕</button>
+      <button id="playBtn" title="Воспроизвести">▶️</button>
+      <button id="exportBtn" title="Экспорт">💾</button>
+      <input type="range" id="onionRange" min="0" max="100" value="30" title="Onion Skin">
+    </div>
+  </div>
+  <div id="frameRail"></div>
+  <script src="https://unpkg.com/gif.js@0.2.0/dist/gif.js"></script>
+  <script type="module" src="src/animator.js"></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Pocket Animator",
+  "short_name": "Animator",
+  "start_url": "animator.html",
+  "display": "standalone",
+  "background_color": "#fefaf6",
+  "description": "Pocket animation studio",
+  "icons": []
+}

--- a/src/animator.js
+++ b/src/animator.js
@@ -1,0 +1,175 @@
+import { hexToRGBA } from './utils.js';
+
+const layers = [
+  document.getElementById('layer0'),
+  document.getElementById('layer1')
+];
+const ctxs = layers.map(l => l.getContext('2d'));
+let activeLayer = 1;
+let canvas = layers[activeLayer];
+let ctx = ctxs[activeLayer];
+
+const colorPicker = document.getElementById('colorPicker');
+const opacityPicker = document.getElementById('opacityPicker');
+const sizePicker = document.getElementById('sizePicker');
+const brushShape = document.getElementById('brushShape');
+const undoBtn = document.getElementById('undoBtn');
+const redoBtn = document.getElementById('redoBtn');
+const clearBtn = document.getElementById('clearBtn');
+const addFrameBtn = document.getElementById('addFrameBtn');
+const playBtn = document.getElementById('playBtn');
+const exportBtn = document.getElementById('exportBtn');
+const onionRange = document.getElementById('onionRange');
+const frameRail = document.getElementById('frameRail');
+const container = document.getElementById('canvasContainer');
+
+const onionCanvas = document.createElement('canvas');
+const onionCtx = onionCanvas.getContext('2d');
+container.insertBefore(onionCanvas, layers[0]);
+
+let frames = [];
+let currentFrame = 0;
+let drawing = false;
+
+function resizeCanvas() {
+  layers.forEach(l => {
+    l.width = window.innerWidth;
+    l.height = container.offsetHeight;
+  });
+  onionCanvas.width = layers[0].width;
+  onionCanvas.height = layers[0].height;
+}
+window.addEventListener('resize', resizeCanvas);
+resizeCanvas();
+
+function renderFrameRail() {
+  frameRail.innerHTML = frames.map((data,i)=>`<img class='thumb ${i===currentFrame?'active':''}' data-idx='${i}' src='${data||''}'>`).join('');
+}
+
+function captureCurrent() {
+  const off = document.createElement('canvas');
+  off.width = layers[0].width;
+  off.height = layers[0].height;
+  const offCtx = off.getContext('2d');
+  layers.forEach(l => offCtx.drawImage(l,0,0));
+  return off.toDataURL();
+}
+
+function saveFrame() {
+  frames[currentFrame] = captureCurrent();
+  renderFrameRail();
+}
+
+function loadFrame(i) {
+  currentFrame = i;
+  ctxs.forEach(c => c.clearRect(0,0,c.canvas.width,c.canvas.height));
+  if (frames[i]) {
+    const img = new Image();
+    img.onload = () => ctx.drawImage(img,0,0);
+    img.src = frames[i];
+  }
+  renderFrameRail();
+  showOnion();
+}
+
+function addFrame(copy=false) {
+  saveFrame();
+  const data = copy ? frames[currentFrame] : null;
+  frames.splice(currentFrame+1,0,data);
+  loadFrame(currentFrame+1);
+}
+
+addFrameBtn.addEventListener('click', () => addFrame(true));
+
+frameRail.addEventListener('click', e => {
+  const idx = e.target.dataset.idx;
+  if (idx) loadFrame(parseInt(idx,10));
+});
+
+function pointerDown(e) {
+  drawing = true;
+  ctx.strokeStyle = colorPicker.value;
+  ctx.globalAlpha = opacityPicker.value/100;
+  ctx.lineWidth = sizePicker.value;
+  ctx.lineCap = brushShape.value === 'square' ? 'butt' : 'round';
+  if (brushShape.value === 'eraser') ctx.globalCompositeOperation = 'destination-out';
+  else ctx.globalCompositeOperation = 'source-over';
+  const r = canvas.getBoundingClientRect();
+  ctx.beginPath();
+  ctx.moveTo(e.clientX - r.left, e.clientY - r.top);
+}
+
+function pointerMove(e) {
+  if (!drawing) return;
+  const r = canvas.getBoundingClientRect();
+  ctx.lineTo(e.clientX - r.left, e.clientY - r.top);
+  ctx.stroke();
+}
+
+function pointerUp() {
+  if (!drawing) return;
+  drawing = false;
+  ctx.closePath();
+  ctx.globalCompositeOperation = 'source-over';
+  saveFrame();
+}
+
+layers.forEach(l => {
+  l.addEventListener('pointerdown', pointerDown);
+  l.addEventListener('pointermove', pointerMove);
+  l.addEventListener('pointerup', pointerUp);
+  l.addEventListener('pointercancel', pointerUp);
+  l.addEventListener('pointerout', pointerUp);
+});
+
+clearBtn.addEventListener('click', () => {
+  ctxs.forEach(c => c.clearRect(0,0,c.canvas.width,c.canvas.height));
+  saveFrame();
+});
+
+function showOnion() {
+  onionCtx.clearRect(0,0,onionCanvas.width,onionCanvas.height);
+  const prev = frames[currentFrame-1];
+  if (prev) {
+    const img = new Image();
+    img.onload = () => {
+      onionCtx.globalAlpha = onionRange.value/100;
+      onionCtx.drawImage(img,0,0);
+    };
+    img.src = prev;
+  }
+}
+
+onionRange.addEventListener('input', showOnion);
+
+function play() {
+  let i = 0;
+  const interval = setInterval(() => {
+    loadFrame(i);
+    i++;
+    if (i >= frames.length) clearInterval(interval);
+  }, 200);
+}
+playBtn.addEventListener('click', play);
+
+function exportGIF() {
+  saveFrame();
+  const gif = new GIF({workers:2,quality:10});
+  frames.forEach(data => {
+    if (!data) return;
+    const img = document.createElement('img');
+    img.src = data;
+    gif.addFrame(img, {delay:200});
+  });
+  gif.on('finished', blob => {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'animation.gif';
+    a.click();
+  });
+  gif.render();
+}
+exportBtn.addEventListener('click', exportGIF);
+
+addFrame(false);

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,18 @@
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open('animator-cache').then(cache => cache.addAll([
+      './animator.html',
+      './manifest.json',
+      './src/animator.js',
+      './src/utils.js',
+      './index.html',
+      './src/game.js'
+    ]))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- create dedicated `animator.html` PWA page with frame rail and toolbar
- implement new animation logic in `src/animator.js`
- add basic service worker and manifest for offline use

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860de01cf248332989d1ecae692c478