### PR TITLE
Add playback controls and undo to animator

### DIFF
--- a/animator.html
+++ b/animator.html
@@ -87,8 +87,12 @@
       <button id="redoBtn" title="Повторить">&#8618;</button>
       <button id="clearBtn" title="Очистить">🗑️</button>
       <button id="addFrameBtn" title="Новый кадр">➕</button>
+      <button id="copyFrameBtn" title="Копировать кадр">📄</button>
       <button id="playBtn" title="Воспроизвести">▶️</button>
+      <label title="Длительность кадра, мс"><input type="number" id="speedInput" value="200" min="50" max="1000" step="50"></label>
+      <label title="Повторять"><input type="checkbox" id="loopCheckbox"></label>
       <button id="exportBtn" title="Экспорт">💾</button>
+      <button id="exportVideoBtn" title="Экспорт видео">📹</button>
       <input type="range" id="onionRange" min="0" max="100" value="30" title="Onion Skin">
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add buttons for frame copy, video export and playback settings
- implement history stack for undo/redo
- allow custom speed and looping when playing
- export animation as WebM video

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68756d0145fc8332a93ee6811bbd779d