### PR TITLE
Fix undo redo per layer

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -69,8 +69,8 @@ layerSelect.addEventListener('change', () => {
 updateVisibility();
 
 let currentTool = 'brush';
-const history = [];
-const redoStack = [];
+const history = [[], []];
+const redoStack = [[], []];
 
 let scale = 1;
 let rotation = 0;
@@ -123,9 +123,10 @@ function checkStorage() {
 }
 
 function saveState() {
-  history.push(canvas.toDataURL());
-  if (history.length > 50) history.shift();
-  redoStack.length = 0;
+  const h = history[activeLayer];
+  h.push(canvas.toDataURL());
+  if (h.length > 50) h.shift();
+  redoStack[activeLayer].length = 0;
   captureFrame();
   autosave();
 }
@@ -321,17 +322,21 @@ clearBtn.addEventListener('click', () => {
 });
 
 undoBtn.addEventListener('click', () => {
-  if (history.length > 0) {
-    redoStack.push(canvas.toDataURL());
-    const data = history.pop();
+  const h = history[activeLayer];
+  const r = redoStack[activeLayer];
+  if (h.length > 0) {
+    r.push(canvas.toDataURL());
+    const data = h.pop();
     restoreState(data);
   }
 });
 
 redoBtn.addEventListener('click', () => {
-  if (redoStack.length > 0) {
-    history.push(canvas.toDataURL());
-    const data = redoStack.pop();
+  const h = history[activeLayer];
+  const r = redoStack[activeLayer];
+  if (r.length > 0) {
+    h.push(canvas.toDataURL());
+    const data = r.pop();
     restoreState(data);
   }
 });
@@ -471,3 +476,5 @@ window.addEventListener('pointerdown', () => {
 });
 window.addEventListener('pointermove', resetToolbarTimer);
 resetToolbarTimer();
+
+export { history, redoStack, saveState };

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1,0 +1,102 @@
+import { JSDOM } from 'jsdom';
+
+const markup = `
+<div id="toolbar"></div>
+<button id="toggleToolbarBtn"></button>
+<button id="moreBtn"></button>
+<input id="colorPicker" />
+<input id="opacityPicker" />
+<input id="sizePicker" />
+<select id="brushShape"></select>
+<button id="zoomInBtn"></button>
+<button id="zoomOutBtn"></button>
+<button id="undoBtn"></button>
+<button id="redoBtn"></button>
+<button id="fillBtn"></button>
+<button id="eyedropperBtn"></button>
+<button id="clearBtn"></button>
+<button id="saveBtn"></button>
+<button id="ambientBtn"></button>
+<button id="gridBtn"></button>
+<div id="quickPalette"></div>
+<select id="layerSelect"><option value="1">1</option><option value="0">0</option></select>
+<label><input type="checkbox" id="showLayer0" checked></label>
+<label><input type="checkbox" id="showLayer1" checked></label>
+<canvas id="layer0"></canvas>
+<canvas id="layer1"></canvas>
+<div id="gridOverlay"></div>
+`;
+
+const dummyCtx = {
+  clearRect() {},
+  drawImage() {},
+  getImageData() { return { data: [0,0,0,255] }; },
+  beginPath() {},
+  moveTo() {},
+  lineTo() {},
+  stroke() {},
+  closePath() {},
+  fillRect() {},
+};
+
+let game;
+let windowRef;
+
+beforeEach(async () => {
+  const dom = new JSDOM(`<!doctype html><html><body>${markup}</body></html>`, {
+    pretendToBeVisual: true,
+    url: 'http://localhost/'
+  });
+  windowRef = dom.window;
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.Image = dom.window.Image;
+  global.localStorage = dom.window.localStorage;
+  Object.defineProperty(dom.window.HTMLCanvasElement.prototype, 'getContext', { value: () => dummyCtx });
+  Object.defineProperty(dom.window.HTMLCanvasElement.prototype, 'toDataURL', { value: () => 'data:' + Math.random() });
+  game = await import('../src/game.js');
+  game.history[0].length = 0;
+  game.history[1].length = 0;
+  game.redoStack[0].length = 0;
+  game.redoStack[1].length = 0;
+});
+
+test('undo and redo are tracked per layer', () => {
+  const { document } = windowRef;
+  const layerSelect = document.getElementById('layerSelect');
+  const undoBtn = document.getElementById('undoBtn');
+  const redoBtn = document.getElementById('redoBtn');
+
+  game.saveState();
+  const first1 = game.history[1][0];
+
+  layerSelect.value = '0';
+  layerSelect.dispatchEvent(new windowRef.Event('change'));
+  game.saveState();
+  const first0 = game.history[0][0];
+
+  layerSelect.value = '1';
+  layerSelect.dispatchEvent(new windowRef.Event('change'));
+  game.saveState();
+  const second1 = game.history[1][1];
+
+  expect(game.history[1]).toEqual([first1, second1]);
+  expect(game.history[0]).toEqual([first0]);
+
+  undoBtn.dispatchEvent(new windowRef.Event('click'));
+  expect(game.history[1]).toEqual([first1]);
+  expect(game.redoStack[1].length).toBe(1);
+  expect(game.redoStack[0].length).toBe(0);
+
+  layerSelect.value = '0';
+  layerSelect.dispatchEvent(new windowRef.Event('change'));
+  undoBtn.dispatchEvent(new windowRef.Event('click'));
+  expect(game.history[0].length).toBe(0);
+  expect(game.redoStack[0].length).toBe(1);
+
+  redoBtn.dispatchEvent(new windowRef.Event('click'));
+  expect(game.history[0].length).toBe(1);
+  expect(game.redoStack[0].length).toBe(0);
+  expect(game.history[1]).toEqual([first1]);
+  expect(game.redoStack[1].length).toBe(1);
+});


### PR DESCRIPTION
## Summary
- maintain history and redoStack for each canvas layer
- update undo/redo logic to use active layer
- export helpers for testing
- add unit test for layer-specific undo/redo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687572336e3883328981ad9aa0a50c76