### PR TITLE
Refactor common drawing logic

### DIFF
--- a/src/drawingCore.js
+++ b/src/drawingCore.js
@@ -1,0 +1,35 @@
+export function beginStroke(ctx, style, pos) {
+  ctx.strokeStyle = style.color;
+  ctx.globalAlpha = style.opacity;
+  ctx.lineWidth = style.size;
+  ctx.globalCompositeOperation =
+    style.shape === 'eraser' ? 'destination-out' : 'source-over';
+  ctx.lineCap = ctx.lineJoin = style.shape === 'square' ? 'butt' : 'round';
+  ctx.beginPath();
+  ctx.moveTo(pos.x, pos.y);
+}
+
+export function drawStroke(ctx, pos) {
+  ctx.lineTo(pos.x, pos.y);
+  ctx.stroke();
+}
+
+export function endStroke(ctx) {
+  ctx.closePath();
+  ctx.globalCompositeOperation = 'source-over';
+}
+
+export function saveState(history, redoStack, data) {
+  history.push(data);
+  if (history.length > 50) history.shift();
+  redoStack.length = 0;
+}
+
+export function restoreState(ctx, data, canvasOverride = null) {
+  const c = canvasOverride || ctx.canvas;
+  ctx.clearRect(0, 0, c.width, c.height);
+  if (!data) return;
+  const img = new Image();
+  img.onload = () => ctx.drawImage(img, 0, 0);
+  img.src = data;
+}

--- a/tests/drawingCore.test.js
+++ b/tests/drawingCore.test.js
@@ -1,0 +1,30 @@
+import { saveState, restoreState } from '../src/drawingCore.js';
+
+class DummyImage {
+  constructor() {
+    this.onload = null;
+  }
+  set src(_) {
+    if (this.onload) this.onload();
+  }
+}
+
+test('saveState manages history and redo', () => {
+  const h = [];
+  const r = ['a'];
+  saveState(h, r, 'data1');
+  expect(h).toEqual(['data1']);
+  expect(r.length).toBe(0);
+});
+
+test('restoreState clears then draws', () => {
+  const calls = [];
+  const ctx = {
+    canvas: { width: 10, height: 10 },
+    clearRect: () => calls.push('clear'),
+    drawImage: () => calls.push('draw')
+  };
+  global.Image = DummyImage;
+  restoreState(ctx, 'data');
+  expect(calls).toEqual(['clear', 'draw']);
+});


### PR DESCRIPTION
## Summary
- create `drawingCore` module for reusable drawing helpers
- use shared helpers in animator and game modes
- add unit tests for the new module

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687573cf5fe0833287242a1f71d209d6