### PR TITLE
Add accessible toolbar labels

### DIFF
--- a/animator.html
+++ b/animator.html
@@ -64,6 +64,17 @@
       padding: 6px;
       background: rgba(232,228,223,0.9);
     }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0,0,0,0);
+      white-space: nowrap;
+      border: 0;
+    }
   </style>
 </head>
 <body>
@@ -83,16 +94,16 @@
         <option value="square">Квадратная</option>
         <option value="eraser">Ластик</option>
       </select>
-      <button id="undoBtn" title="Отменить">&#8617;</button>
-      <button id="redoBtn" title="Повторить">&#8618;</button>
-      <button id="clearBtn" title="Очистить">🗑️</button>
-      <button id="addFrameBtn" title="Новый кадр">➕</button>
-      <button id="copyFrameBtn" title="Копировать кадр">📄</button>
-      <button id="playBtn" title="Воспроизвести">▶️</button>
+      <button id="undoBtn" title="Отменить" aria-label="Отменить">&#8617;<span class="sr-only">Отменить</span></button>
+      <button id="redoBtn" title="Повторить" aria-label="Повторить">&#8618;<span class="sr-only">Повторить</span></button>
+      <button id="clearBtn" title="Очистить" aria-label="Очистить">🗑️<span class="sr-only">Очистить</span></button>
+      <button id="addFrameBtn" title="Новый кадр" aria-label="Новый кадр">➕<span class="sr-only">Новый кадр</span></button>
+      <button id="copyFrameBtn" title="Копировать кадр" aria-label="Копировать кадр">📄<span class="sr-only">Копировать кадр</span></button>
+      <button id="playBtn" title="Воспроизвести" aria-label="Воспроизвести">▶️<span class="sr-only">Воспроизвести</span></button>
       <label title="Длительность кадра, мс"><input type="number" id="speedInput" value="200" min="50" max="1000" step="50"></label>
       <label title="Повторять"><input type="checkbox" id="loopCheckbox"></label>
-      <button id="exportBtn" title="Экспорт">💾</button>
-      <button id="exportVideoBtn" title="Экспорт видео">📹</button>
+      <button id="exportBtn" title="Экспорт" aria-label="Экспорт">💾<span class="sr-only">Экспорт</span></button>
+      <button id="exportVideoBtn" title="Экспорт видео" aria-label="Экспорт видео">📹<span class="sr-only">Экспорт видео</span></button>
       <input type="range" id="onionRange" min="0" max="100" value="30" title="Onion Skin">
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -157,12 +157,23 @@
       background-size: 20px 20px;
       display: none;
     }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0,0,0,0);
+      white-space: nowrap;
+      border: 0;
+    }
   </style>
 </head>
 <body>
   <div id="toolbar">
-    <button id="toggleToolbarBtn" title="Свернуть панель">▼</button>
-    <button id="moreBtn" title="Дополнительно">☰</button>
+    <button id="toggleToolbarBtn" title="Свернуть панель" aria-label="Свернуть панель">▼</button>
+    <button id="moreBtn" title="Дополнительно" aria-label="Дополнительно">☰<span class="sr-only">Дополнительно</span></button>
     <input type="color" id="colorPicker" title="Цвет кисти" value="#000000">
     <label title="Прозрачность">
       <input type="range" id="opacityPicker" min="0" max="100" value="100">
@@ -175,18 +186,18 @@
       <option value="square">Квадратная</option>
       <option value="eraser">Ластик</option>
     </select>
-    <button id="undoBtn" title="Отменить">&#8617;</button>
-    <button id="redoBtn" title="Повторить">&#8618;</button>
-    <button id="clearBtn" title="Очистить">🗑️</button>
-    <button id="saveBtn" title="Сохранить">💾</button>
-    <a id="animatorBtn" href="animator.html" title="Анимация">🎞️</a>
+    <button id="undoBtn" title="Отменить" aria-label="Отменить">&#8617;<span class="sr-only">Отменить</span></button>
+    <button id="redoBtn" title="Повторить" aria-label="Повторить">&#8618;<span class="sr-only">Повторить</span></button>
+    <button id="clearBtn" title="Очистить" aria-label="Очистить">🗑️<span class="sr-only">Очистить</span></button>
+    <button id="saveBtn" title="Сохранить" aria-label="Сохранить">💾<span class="sr-only">Сохранить</span></button>
+    <a id="animatorBtn" href="animator.html" title="Анимация" aria-label="Анимация">🎞️<span class="sr-only">Анимация</span></a>
     <div id="advancedControls">
-      <button id="zoomInBtn"  title="Приблизить">+</button>
-      <button id="zoomOutBtn" title="Отдалить">-</button>
-      <button id="fillBtn" title="Заливка">🪣</button>
-      <button id="eyedropperBtn" title="Пипетка">🎨</button>
-      <button id="ambientBtn" title="Звук">🎵</button>
-      <button id="gridBtn" title="Сетка">#</button>
+      <button id="zoomInBtn"  title="Приблизить" aria-label="Приблизить">+<span class="sr-only">Приблизить</span></button>
+      <button id="zoomOutBtn" title="Отдалить" aria-label="Отдалить">-<span class="sr-only">Отдалить</span></button>
+      <button id="fillBtn" title="Заливка" aria-label="Заливка">🪣<span class="sr-only">Заливка</span></button>
+      <button id="eyedropperBtn" title="Пипетка" aria-label="Пипетка">🎨<span class="sr-only">Пипетка</span></button>
+      <button id="ambientBtn" title="Звук" aria-label="Звук">🎵<span class="sr-only">Звук</span></button>
+      <button id="gridBtn" title="Сетка" aria-label="Сетка">#<span class="sr-only">Сетка</span></button>
       <div id="quickPalette" title="Быстрые цвета"></div>
       <select id="layerSelect" title="Слой">
         <option value="1">Объекты</option>


### PR DESCRIPTION
## Summary
- add `.sr-only` style to hide labels visually
- include `aria-label` on every toolbar button with hidden text for screen readers
- include the same in animator view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6875928b5c8083328b65b93e199f346c